### PR TITLE
[Fix] Weird space in txt-greating

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "prettier.jsxSingleQuote": true
+}

--- a/components/AnimatedLetters.js
+++ b/components/AnimatedLetters.js
@@ -3,7 +3,7 @@ function AnimatedLetters({ letterClass, text = "GeraAlcantara", idx }) {
     <span>
       {text.split("").map((char, i) => (
         <span className={`${letterClass} _${i + idx} `} key={i + idx}>
-          {char}
+          {char === " " ? <>&nbsp;</> : char}
         </span>
       ))}
     </span>

--- a/pages/index.js
+++ b/pages/index.js
@@ -34,14 +34,24 @@ export default function Home() {
             <div className='bg-gradient-to-br from-bg_secondary/70 via-bg_secondary/50 to-bg_secondary/0 w-40 h-40 block rounded-full absolute -left-8 -top-10 '></div>
             <div className='relative'>
               <h1 className='font-Urbanist leading-none xl:text-4xl xl:top-4 xl:relative'>
-                <AnimatedLetters letterClass={` ${letterClasssup} `} text={txtgreating} idx={0}></AnimatedLetters>
+                <AnimatedLetters
+                  letterClass={` ${letterClasssup} `}
+                  text={txtgreating}
+                  idx={0}
+                ></AnimatedLetters>
               </h1>
               <p className='font-Raleway font-extrabold text-4xl xl:text-9xl text-accent leading-none transition-all '>
-                <AnimatedLetters letterClass={` ${letterClass} `} text={titlename} idx={10}></AnimatedLetters>
+                <AnimatedLetters
+                  letterClass={` ${letterClass} `}
+                  text={titlename}
+                  idx={10}
+                ></AnimatedLetters>
               </p>
               <p className={`max-w-prose mt-8 opacity-0 ${paragraphClass}`}>
-                Lorem ipsum, dolor sit amet consectetur adipisicing elit. Assumenda soluta molestias adipisci placeat distinctio facere quia sed quisquam, quas
-                eos ratione eum architecto repellat reiciendis ducimus laboriosam ipsum ipsa iusto.
+                Lorem ipsum, dolor sit amet consectetur adipisicing elit.
+                Assumenda soluta molestias adipisci placeat distinctio facere
+                quia sed quisquam, quas eos ratione eum architecto repellat
+                reiciendis ducimus laboriosam ipsum ipsa iusto.
               </p>
             </div>
           </div>

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -5,7 +5,6 @@
 .animatedLeters {
     display: inline-block;
     opacity: 0;
-    min-width: 10px;
     animation: bounce-in-fwd 1s 1s;
     animation-fill-mode: forwards;
     animation-timing-function: cubic-bezier(0.95, 0.05, 0.795, 0.035);
@@ -14,7 +13,6 @@
 .animatedLeters-hover {
     display: inline-block;
     animation-fill-mode: both;
-    min-width: 10px;
 
     &:hover {
         animation: jello-horizontal 0.6s ease-in-out;


### PR DESCRIPTION
used `&nbsp;` html character to simulate space.
`{text.split("").map((char, i) => (
  <span ...>
    {char === " " ? <>&nbsp;</> : char}
  </span>
))}`

For more info: https://www.w3schools.com/html/html_entities.asp

Works well in desktop or mobile:
![desktop screenshot](https://user-images.githubusercontent.com/56652199/197588650-56011e5c-d100-4f0d-b199-71991c5e179c.png)

![mobile screenshot](https://user-images.githubusercontent.com/56652199/197588854-0140027f-e1a6-4982-b759-176303b42dad.png)
